### PR TITLE
Fixed extension ID

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -4,7 +4,7 @@
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 
   <Description about="urn:mozilla:install-manifest">
-    <em:id>filelink@nextcloud.com</em:id>
+    <em:id>owncloud@viguierjust.com</em:id>
     <em:name>Nextcloud for Filelink</em:name>
     <em:version>1.5</em:version>
     <em:type>2</em:type>


### PR DESCRIPTION
I found out that Thunderbird does not allow me to change the ID of the extension, so I have to leave it as owncloud@viguierjust.com. Let me know if it's an issue for you.