### PR TITLE
Change field for password for uploaded files in settings view

### DIFF
--- a/src/chrome/content/settings.xhtml
+++ b/src/chrome/content/settings.xhtml
@@ -49,7 +49,7 @@
 	<label for="storageFolder">&nextcloudSettings.storageFolder;</label>
 	<input id="storageFolder" type="text" required="true" value="/Mail-attachments"/>
 	<label for="protectUploads">&nextcloudSettings.protectUploads;</label>
-	<input id="protectUploads" type="text" value=""/>
+	<input id="protectUploads" type="password" value=""/>
 </form>
 <div id="learn-more">
 	<a href="https://nextcloud.com/">&nextcloudSettings.learnMore;</a>


### PR DESCRIPTION
### Description
When typing a password for upload in settings it needs to be hidden.

### Screenshots
![set up filelink_030](https://cloud.githubusercontent.com/assets/2707508/25135102/b3b9fc96-2451-11e7-9b31-cfecbfcf75e8.png)

### Tested on

- [ ] Windows/Thunderbird
- [x] Linux/Thunderbird
- [ ] macOS/Thunderbird
