### PR TITLE
Create a folder if the folder entered in the settings doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It is currently possible to upload files as large as 1GB.
 ## Nextcloud configuration
 
 1. Make sure that you have checked "Allow users to share via link" in the **"Sharing"** section of the admin page of your Nextcloud installation. If you have also checked-in the **"Enforce password protection"** option, make sure to fill the **"Password for uploaded files"** field when setting up the add-on in Thunderbird
-1. By default your mail attachments will be saved in a folder called `Mail-attachments`. You currently need to create that folder in the root folder of your Nextcloud prior to using the Thunderbird add-on
+1. By default your mail attachments will be saved in a folder called `Mail-attachments`.
 
 *Note: It's also possible to use a different folder name. Simply type the name of the folder you want to use when setting up the provider in Thunderbird*
 


### PR DESCRIPTION
Fixes: https://github.com/nextcloud/nextcloud-filelink/issues/16

Licence: AGPL3+ or any other compatible license

### Description

Create a folder on server if the folder entered in the settings doesn't exist
 
### Tested on

- [ ] Windows/Thunderbird
- [x] Linux/Thunderbird
- [ ] macOS/Thunderbird

### TODO

- [ ] Modify function to create multiple folders entered in this format : `/a/b/c` if `/a/b` doesn't exist.
- [ ] Add popup to confirm folder creation
