### PR TITLE
Compatibility with thunderbird-60, fixes #55

### DIFF
--- a/src/components/nsNextcloud.js
+++ b/src/components/nsNextcloud.js
@@ -35,6 +35,7 @@ Cu.import("resource:///modules/oauth.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource:///modules/gloda/log4moz.js");
 Cu.import("resource:///modules/cloudFileAccounts.js");
+Cu.importGlobalProperties(["XMLHttpRequest"]);
 
 const kRestBase = "/ocs/v1.php";
 const kAuthPath = kRestBase + "/cloud/user";
@@ -435,8 +436,7 @@ Nextcloud.prototype = {
 		this.log.info("Sending login information...");
 
 		let args = "?format=json";
-		let req = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"]
-			.createInstance(Ci.nsIXMLHttpRequest);
+		let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 
 		req.open("GET", this._fullUrl + kAuthPath + args, true);
 		req.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
@@ -575,8 +575,7 @@ Nextcloud.prototype = {
 			'</prop>' +
 			'</propfind>';
 
-		let req = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(
-			Ci.nsIXMLHttpRequest);
+		let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 
 		req.open("PROPFIND", this._fullUrl + kWebDavPath, true,
 			this._userName, this._password);
@@ -638,8 +637,7 @@ Nextcloud.prototype = {
 				'</prop>' +
 				'</propfind>';
 
-			let req = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"]
-				.createInstance(Ci.nsIXMLHttpRequest);
+			let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 
 			req.open("PROPFIND", this._fullUrl + kWebDavPath +
 				("/" + this._storageFolder + "/").replace(/\/+/g, '/'), true, this._userName,
@@ -674,8 +672,7 @@ Nextcloud.prototype = {
 	 */
 	_createFolder: function createFolder(callback) {
 		if (this._storageFolder !== '/') {
-			let req = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"]
-				.createInstance(Ci.nsIXMLHttpRequest);
+			let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 
 			req.open("MKCOL", this._fullUrl + kWebDavPath +
 				("/" + this._storageFolder + "/").replace(/\/+/g, '/'), true, this._userName,
@@ -778,8 +775,7 @@ NextcloudFileUploader.prototype = {
 		bufStream = bufStream.QueryInterface(Ci.nsIInputStream);
 		let contentLength = fstream.available();
 
-		let req = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(
-			Ci.nsIXMLHttpRequest);
+		let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 
 		req.open("PUT", url, true, this._userName, this._password);
 
@@ -835,8 +831,7 @@ NextcloudFileUploader.prototype = {
 		this.file = aFile;
 		let shareType = 3;
 		let args = "?format=json";
-		let req = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"]
-			.createInstance(Ci.nsIXMLHttpRequest);
+		let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 		let path = wwwFormUrlEncode(
 			("/" + this.nextcloud._storageFolder + "/").replace(/\/+/g, '/') +
 			this._fileUploadTS[this.file.path] + "_" + this.file.leafName);

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -6,7 +6,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>owncloud@viguierjust.com</em:id>
     <em:name>Nextcloud for Filelink</em:name>
-    <em:version>1.7</em:version>
+    <em:version>1.7.1</em:version>
     <em:type>2</em:type>
     <em:creator>Olivier Paroz</em:creator>
     <em:contributor>Philipp Kewisch</em:contributor>
@@ -21,7 +21,7 @@
       <Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
         <em:minVersion>17.0</em:minVersion>
-        <em:maxVersion>57.*</em:maxVersion>
+        <em:maxVersion>60.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
Fixes: *#55*

Licence: AGPL3+ or any other compatible license

### Description

I tried to use nexcloud-filelink within thunderbird 60. I got it up and running
by this:

- upgrade to thunderbird 60
- existing filelink doesn't work any more
- create an xpi
    - `cd src`
    - `zip -r /tmp/fl.xpi .`
- install the xpi within thunderbird 60
- seems to work now

I used these instructions: https://wiki.mozilla.org/Thunderbird/Add-ons_Guide_57

### Tests

I tested on Linux/Thunderbird-60 only.

### TODO
-  do test on other platforms
-  do test the initial configuration of filelink
