### PR TITLE
Fixed WebDAV authentication bug and send credentials in post

### DIFF
--- a/src/chrome/content/management.js
+++ b/src/chrome/content/management.js
@@ -23,8 +23,8 @@
  */
 
 function onLoadProvider (provider) {
-  let messenger = Cc["@mozilla.org/messenger;1"]
-                    .createInstance(Ci.nsIMessenger);
+	let messenger = Components.classes["@mozilla.org/messenger;1"]
+		.createInstance(Components.interfaces.nsIMessenger);
 
 	let fileSpaceUsed = document.getElementById("file-space-used");
 	let fileSpaceUsedSwatch = document.getElementById("file-space-used-swatch");

--- a/src/components/nsNextcloud.js
+++ b/src/components/nsNextcloud.js
@@ -608,7 +608,6 @@ Nextcloud.prototype = {
 						} else if (!spaceAvailable || spaceAvailable < 0) { // 0 or negative
 							this._totalStorage = 0;
 						}
-						console.log(this._fileSpaceUsed, "$", this._totalStorage)
 						successCallback();
 					} else {
 						failureCallback();
@@ -819,7 +818,11 @@ NextcloudFileUploader.prototype = {
 		}.bind(this);
 
 		req.setRequestHeader("Content-Length", contentLength);
-		req.sendInputStream(bufStream);
+		if (req.sendInputStream) { // Fix for old TB
+			req.sendInputStream(bufStream);
+		} else {
+			req.send(bufStream);
+		}
 	},
 
 	/**

--- a/src/components/nsNextcloud.js
+++ b/src/components/nsNextcloud.js
@@ -642,11 +642,14 @@ Nextcloud.prototype = {
 				'</prop>' +
 				'</propfind>';
 
-			let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
+			let req = new XMLHttpRequest(Object.assign({mozAnon: true}, Ci.nsIXMLHttpRequest));
 
 			req.open("PROPFIND", this._fullUrl + kWebDavPath +
-				("/" + this._storageFolder + "/").replace(/\/+/g, '/'), true, this._userName,
-				this._password);
+				("/" + this._storageFolder + "/").replace(/\/+/g, '/'), true);
+
+			req.setRequestHeader("Authorization",
+				"Basic " + btoa(this._userName + ':' + this._password));
+
 			req.onerror = function () {
 				this.log.info("Failed to check if folder exists");
 				callback(false);
@@ -677,11 +680,13 @@ Nextcloud.prototype = {
 	 */
 	_createFolder: function createFolder(callback) {
 		if (this._storageFolder !== '/') {
-			let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
+			let req = new XMLHttpRequest(Object.assign({mozAnon: true}, Ci.nsIXMLHttpRequest));
 
 			req.open("MKCOL", this._fullUrl + kWebDavPath +
-				("/" + this._storageFolder + "/").replace(/\/+/g, '/'), true, this._userName,
-				this._password);
+				("/" + this._storageFolder + "/").replace(/\/+/g, '/'), true);
+
+			req.setRequestHeader("Authorization",
+				"Basic " + btoa(this._userName + ':' + this._password));
 
 			req.onload = function () {
 				if (req.status === 201) {
@@ -780,9 +785,6 @@ NextcloudFileUploader.prototype = {
 		bufStream = bufStream.QueryInterface(Ci.nsIInputStream);
 		let contentLength = fstream.available();
 
-		let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
-
-
 		let password = this.nextcloud.getPassword(this.nextcloud._userName, false);
 
 		if (password === "") {
@@ -790,8 +792,12 @@ NextcloudFileUploader.prototype = {
 			return;
 		}
 
+		let req = new XMLHttpRequest(Object.assign({mozAnon: true}, Ci.nsIXMLHttpRequest));
 
-		req.open("PUT", url, true, this.nextcloud._userName, password);
+		req.open("PUT", url, true);
+
+		req.setRequestHeader("Authorization",
+			"Basic " + btoa(this.nextcloud._userName + ':' + password));
 
 		req.onerror = function () {
 			this.log.error("Could not upload file");


### PR DESCRIPTION
Fixes the WebDAV authentication bug which resulted in an “503 Service Unavailable” error and improved the security by sending the credentials in the header instead of the url.

--- and ---

Bug fix for old thunderbird 52.9.1 on linux where the space screen not worked because of a missing import of Components.classes as Cc, also the file upload had stopped working because the sendInputStream method is not available in the old TB.

Fixes: #59, #61

Licence: AGPL3+ or any other compatible license