### PR TITLE
Making owncloud/Sciebo working again

### DIFF
--- a/src/components/nsNextcloud.js
+++ b/src/components/nsNextcloud.js
@@ -39,6 +39,7 @@ Cu.importGlobalProperties(["XMLHttpRequest"]);
 
 const kRestBase = "/ocs/v1.php";
 const kAuthPath = kRestBase + "/cloud/user";
+const kInfoPath = kRestBase + "/cloud/users";
 const kShareApp = kRestBase + "/apps/files_sharing/api/v1/shares";
 const kWebDavPath = "/remote.php/webdav";
 
@@ -576,7 +577,7 @@ Nextcloud.prototype = {
 		let args = "?format=json";
 		let req = new XMLHttpRequest(Ci.nsIXMLHttpRequest);
 
-		req.open("GET", this._fullUrl + kAuthPath + args, true);
+		req.open("GET", this._fullUrl + kInfoPath + '/' + this._userName + args, true);
 		req.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 		req.setRequestHeader("OCS-APIREQUEST", "true");
 		req.setRequestHeader("Authorization",


### PR DESCRIPTION
See https://github.com/nextcloud/nextcloud-filelink/issues/65
Change path for retrieving userinfo from "/cloud/user" to "/cloud/users/USERNAME"

Fixes: 65

Licence: AGPL3+ or any other compatible license

### Description

Using "/cloud/users/USERNAME" for retrieving quota info

### Features

Making owncloud/Scibo and Nexcloud work.
