### PR TITLE
Set expiration for shared links

### DIFF
--- a/src/chrome/content/settings.js
+++ b/src/chrome/content/settings.js
@@ -36,7 +36,8 @@ function extraArgs () {
 	let portValue = document.getElementById("port").value;
 	let storageFolderValue = document.getElementById("storageFolder").value;
 	let userValue = document.getElementById("username").value;
-	let protectUploadsValue = document.getElementById("protectUploads").value;
+    let protectUploadsValue = document.getElementById("protectUploads").value;
+    let days2expiryValue = document.getElementById("days2expiry").value;
 
 	return {
 		"displayName": {
@@ -62,6 +63,10 @@ function extraArgs () {
 		"protectUploads": {
 			type: "char",
 			value: protectUploadsValue
+		},
+		"days2expiry": {
+			type: "int",
+			value: days2expiryValue
 		}
 	};
 }

--- a/src/chrome/content/settings.xhtml
+++ b/src/chrome/content/settings.xhtml
@@ -50,6 +50,8 @@
 	<input id="storageFolder" type="text" required="true" value="/Mail-attachments"/>
 	<label for="protectUploads">&nextcloudSettings.protectUploads;</label>
 	<input id="protectUploads" type="password" value=""/>
+	<label for="days2expiry">&nextcloudSettings.days2expiry;</label>
+	<input id="days2expiry" pattern="[0-9]+" required="false" value="0"/>
 </form>
 <div id="learn-more">
 	<a href="https://nextcloud.com/">&nextcloudSettings.learnMore;</a>

--- a/src/chrome/locale/de/settings.dtd
+++ b/src/chrome/locale/de/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Benutzername">
 		<!ENTITY nextcloudSettings.password "Passwort">
 		<!ENTITY nextcloudSettings.protectUploads "Passwort für hochgeladene Dateien">
+		<!ENTITY nextcloudSettings.days2expiry "Anzahl Tage bis zum Ablauf">

--- a/src/chrome/locale/en/settings.dtd
+++ b/src/chrome/locale/en/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Username">
 		<!ENTITY nextcloudSettings.password "Password">
 		<!ENTITY nextcloudSettings.protectUploads "Password for uploaded files">
+		<!ENTITY nextcloudSettings.days2expiry "Number of days to expiration">

--- a/src/chrome/locale/es/settings.dtd
+++ b/src/chrome/locale/es/settings.dtd
@@ -30,3 +30,4 @@
 <!ENTITY nextcloudSettings.username "Nombre de usuario">
 <!ENTITY nextcloudSettings.password "Contraseña">
 <!ENTITY nextcloudSettings.protectUploads "Contraseña para archivos cargados">
+<!ENTITY nextcloudSettings.days2expiry "Número de días hasta el vencimiento">

--- a/src/chrome/locale/fr/settings.dtd
+++ b/src/chrome/locale/fr/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Nom d'utilisateur">
 		<!ENTITY nextcloudSettings.password "Mot de passe">
 		<!ENTITY nextcloudSettings.protectUploads "Mot de passe pour fichiers téléversés">
+		<!ENTITY nextcloudSettings.days2expiry "Nombre de jours avant expiration">

--- a/src/chrome/locale/nl/settings.dtd
+++ b/src/chrome/locale/nl/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Gebruikersnaam">
 		<!ENTITY nextcloudSettings.password "Wachtwoord">
 		<!ENTITY nextcloudSettings.protectUploads "Wachtwoord voor geüploade bestanden">
+		<!ENTITY nextcloudSettings.days2expiry "Aantal dagen tot expiratie">

--- a/src/chrome/locale/pl/settings.dtd
+++ b/src/chrome/locale/pl/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Twoja nazwa użytkownika">
 		<!ENTITY nextcloudSettings.password "Twoje hasło">
 		<!ENTITY nextcloudSettings.protectUploads "Hasło dostępu do wgranych załączników">
+		<!ENTITY nextcloudSettings.days2expiry "Liczba dni do wygaśnięcia">

--- a/src/components/nsNextcloud.js
+++ b/src/components/nsNextcloud.js
@@ -133,6 +133,7 @@ Nextcloud.prototype = {
 	_uploads: [],
 	_urlsForFiles: {},
 	_uploadInfo: {}, // upload info keyed on aFiles.
+	_days2expiry: 0,
 
 	/**
 	 * Initialize this instance of Nextcloud, setting the accountKey.
@@ -168,6 +169,8 @@ Nextcloud.prototype = {
 		if (this._prefBranch.prefHasUserValue("protectUploads")) {
 			this._protectUploads = this._prefBranch.getCharPref("protectUploads");
 		}
+
+		this._days2expiry = this._prefBranch.getIntPref("days2expiry");
 	},
 
 	/**
@@ -868,6 +871,13 @@ NextcloudFileUploader.prototype = {
 		// Request a password for the link if it has been defined during setup time
 		if (this.nextcloud._protectUploads.length) {
 			formData += "&password=" + wwwFormUrlEncode(this.nextcloud._protectUploads);
+		}
+
+		if (this.nextcloud._days2expiry) {
+			var expiry = new Date();
+			expiry.setTime(expiry.getTime() + this.nextcloud._days2expiry * 24 * 3600 * 1000);
+			expiry.setMinutes(expiry.getMinutes() - expiry.getTimezoneOffset());
+			formData += "&expireDate=" + expiry.toISOString().slice(0, 10);
 		}
 
 		req.open("POST",


### PR DESCRIPTION
The generated shares will expire after a given number of days. A value of 0 disables this feature.

Please note, that once the share is expired, file is **not** deleted automatically. 
