### PR TITLE
Add random password generation support for each upload

### DIFF
--- a/src/chrome/content/settings.js
+++ b/src/chrome/content/settings.js
@@ -28,7 +28,7 @@
  *     string, value: *}, port: {type: string, value: (string|string|string|Number)},
  *     storageFolder: {type: string, value: (string|string|string|Number)}, username: {type:
  *     string, value: (string|string|string|Number)}, protectUploads: {type: string, value:
- *     (string|string|string|Number)}}}
+ *     (string|string|string|Number), useRandomPassword: {type: bool, value: bool}}}
  */
 function extraArgs () {
 	let displayName = document.getElementById("displayName").value;
@@ -37,6 +37,7 @@ function extraArgs () {
 	let storageFolderValue = document.getElementById("storageFolder").value;
 	let userValue = document.getElementById("username").value;
 	let protectUploadsValue = document.getElementById("protectUploads").value;
+	let useRandomPasswordValue = document.getElementById("useRandomPassword").checked;
 
 	return {
 		"displayName": {
@@ -62,6 +63,19 @@ function extraArgs () {
 		"protectUploads": {
 			type: "char",
 			value: protectUploadsValue
+		},
+		"useRandomPassword": {
+			type: "bool",
+			value: useRandomPasswordValue
 		}
 	};
+}
+
+function onUseRandomPasswordClick () {
+	let useRandomPassword = document.getElementById("useRandomPassword").checked;
+	if (useRandomPassword) {
+		document.getElementById("protectUploads").disabled = "disabled";
+	} else {
+		document.getElementById("protectUploads").disabled = "";
+	}
 }

--- a/src/chrome/content/settings.xhtml
+++ b/src/chrome/content/settings.xhtml
@@ -50,6 +50,9 @@
 	<input id="storageFolder" type="text" required="true" value="/Mail-attachments"/>
 	<label for="protectUploads">&nextcloudSettings.protectUploads;</label>
 	<input id="protectUploads" type="password" value=""/>
+	<label for="useRandomPassword">
+		<input id="useRandomPassword" type="checkbox" style="display: inline-block; width: auto;" onclick="onUseRandomPasswordClick();"/>&nextcloudSettings.useRandomPassword;
+	</label>
 </form>
 <div id="learn-more">
 	<a href="https://nextcloud.com/">&nextcloudSettings.learnMore;</a>

--- a/src/chrome/locale/de/settings.dtd
+++ b/src/chrome/locale/de/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Benutzername">
 		<!ENTITY nextcloudSettings.password "Passwort">
 		<!ENTITY nextcloudSettings.protectUploads "Passwort für hochgeladene Dateien">
+		<!ENTITY nextcloudSettings.useRandomPassword "Verwenden Sie für jeden Upload ein zufälliges Passwort">

--- a/src/chrome/locale/en/settings.dtd
+++ b/src/chrome/locale/en/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Username">
 		<!ENTITY nextcloudSettings.password "Password">
 		<!ENTITY nextcloudSettings.protectUploads "Password for uploaded files">
+		<!ENTITY nextcloudSettings.useRandomPassword "Use random password for each upload">

--- a/src/chrome/locale/es/settings.dtd
+++ b/src/chrome/locale/es/settings.dtd
@@ -30,3 +30,4 @@
 <!ENTITY nextcloudSettings.username "Nombre de usuario">
 <!ENTITY nextcloudSettings.password "Contraseña">
 <!ENTITY nextcloudSettings.protectUploads "Contraseña para archivos cargados">
+<!ENTITY nextcloudSettings.useRandomPassword "Utilice una contraseña aleatoria para cada carga">

--- a/src/chrome/locale/fr/settings.dtd
+++ b/src/chrome/locale/fr/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Nom d'utilisateur">
 		<!ENTITY nextcloudSettings.password "Mot de passe">
 		<!ENTITY nextcloudSettings.protectUploads "Mot de passe pour fichiers téléversés">
+		<!ENTITY nextcloudSettings.useRandomPassword "Utilisez un mot de passe aléatoire pour chaque téléchargement">

--- a/src/chrome/locale/nl/settings.dtd
+++ b/src/chrome/locale/nl/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Gebruikersnaam">
 		<!ENTITY nextcloudSettings.password "Wachtwoord">
 		<!ENTITY nextcloudSettings.protectUploads "Wachtwoord voor geüploade bestanden">
+		<!ENTITY nextcloudSettings.useRandomPassword "Gebruik een willekeurig wachtwoord voor elke upload">

--- a/src/chrome/locale/pl/settings.dtd
+++ b/src/chrome/locale/pl/settings.dtd
@@ -30,3 +30,4 @@
 		<!ENTITY nextcloudSettings.username "Twoja nazwa użytkownika">
 		<!ENTITY nextcloudSettings.password "Twoje hasło">
 		<!ENTITY nextcloudSettings.protectUploads "Hasło dostępu do wgranych załączników">
+		<!ENTITY nextcloudSettings.useRandomPassword "Użyj losowego hasła do każdego przesyłania">


### PR DESCRIPTION
Fixes: #54

Licence: AGPL3+ or any other compatible license

### Description

This patch add random password generation support for each upload.
The generated password is printed at the beginning of the message body.
Also, if it disable the random password option, the fixed password is printed at the beginning of the message body.

### Features

* Add random password generation support for each upload.
* The generated password is printed at the beginning of the message body.
* If you disable the random password option, the fixed password is printed at the beginning of the message body.

### Screenshots or screencasts

![nextcloud-filelink-random-password-config](https://user-images.githubusercontent.com/128867/58763970-cd768600-859c-11e9-9bc5-d1f23d2bcbec.png)
![nextcloud-filelink-random-password-textmail](https://user-images.githubusercontent.com/128867/58763973-cfd8e000-859c-11e9-82f3-dabf97338290.png)
![nextcloud-filelink-random-password-htmlmail](https://user-images.githubusercontent.com/128867/58763974-d1a2a380-859c-11e9-8128-df4538fa8bea.png)

## Tests

### Test plan
 
- [Test addon file](https://github.com/jfut/nextcloud-filelink/releases/download/random-password/nextcloud-filelink-random-password.xpi)

### Tested on

- [x] Windows/Thunderbird
- [x] Linux/Thunderbird
- [x] macOS/Thunderbird

### Check list

- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Commits have been squashed
- [x] Documentation (manuals or wiki) has been updated or is not required

### Reviewers
<!--
Please list below the Github handles of people suceptible to review this PR
-->
