### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/nsNextcloud.js
+++ b/src/components/nsNextcloud.js
@@ -385,7 +385,7 @@ Nextcloud.prototype = {
 		// Use the service name in the prompt text
     let userPos = this._fullUrl.indexOf("//") + 2;
     let userNamePart = encodeURIComponent(this._userName) + '@';
-    let serverUrl = this._fullUrl.substr(0, userPos) + userNamePart + this._fullUrl.substr(userPos);
+    let serverUrl = this._fullUrl.slice(0, userPos) + userNamePart + this._fullUrl.slice(userPos);
 		let messengerBundle = Services.strings.createBundle(
 			"chrome://messenger/locale/messenger.properties");
 		let promptString = messengerBundle.formatStringFromName("passwordPrompt",


### PR DESCRIPTION
### Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Caveats
None

## Tests

### Test plan
<!--
Add each test which should be performed and give a general description of the context
You can also link to one or more entries from the "Acceptance tests" section in the wiki
-->

 
### Tested on

- [ ] Windows/Thunderbird
- [ ] Linux/Thunderbird
- [ ] macOS/Thunderbird

### Check list

- [ ] Code is properly documented
- [ ] Code is properly formatted
- [x] Commits have been squashed
- [ ] Documentation (manuals or wiki) has been updated or is not required

### Reviewers

